### PR TITLE
Strip trailing period from qname

### DIFF
--- a/rev.pl
+++ b/rev.pl
@@ -317,6 +317,7 @@ sub do_lookup {
   my $self = shift;
   my $p = shift;
   my $name = $p->{qname};
+  $name =~ s/\.$//;
   my $type = $p->{qtype};
   my $d = $self->d;
   my $stmt;


### PR DESCRIPTION
This ensures compatibility with PowerDNS 4.0.x without modifying existing queries. This may cause other unexpected effects. Fixes #8
